### PR TITLE
Fixing NPE when a Show property is null

### DIFF
--- a/data/src/main/java/me/giacoppo/examples/kotlin/mvp/data/source/tmdb/model/mapper/TVShowMapper.kt
+++ b/data/src/main/java/me/giacoppo/examples/kotlin/mvp/data/source/tmdb/model/mapper/TVShowMapper.kt
@@ -6,7 +6,7 @@ import me.giacoppo.examples.kotlin.mvp.data.source.tmdb.model.TVShow
 class TVShowMapper : (TVShow) -> Show {
     override fun invoke(model: TVShow): Show {
         with(model) {
-            return Show(id, name!!, overview!!, originalLanguage!!, "https://image.tmdb.org/t/p/w500/" + backdropPath!!, "https://image.tmdb.org/t/p/w500/" + posterPath!!)
+            return Show(id, name ?: "", overview ?: "", originalLanguage ?: "", "https://image.tmdb.org/t/p/w500/" + (backdropPath ?: ""), "https://image.tmdb.org/t/p/w500/" + (posterPath ?: ""))
         }
     }
 }


### PR DESCRIPTION
The app was crashing because of a NPE. Turns out that for some reason The Face of Analia has no backdrop picture. So I'm using the elvis operator in place of the !! operator.